### PR TITLE
Clarification on log rotation when process start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Creates a new GoodFile object where:
 	 	- `[extension]` - file extension to use when creating a file. Defaults to ".log". Set to "" for no extension.
 	 	- `[prefix]` - file name prefix to use when creating a file. Defaults to "good-file"
 	 	- `[rotate]` - a string indicating a log rotation time span. The designated time span will start a timer that will trigger at the *end* of the specified time span. For example, using "daily", a new log file would be created at *approximately* 11:59:59.999 on the current day. Please see [this section](http://momentjs.com/docs/#/manipulating/end-of/) in the Moment.js documentation for more details. The string must be one of the following values: ['hourly', 'daily', 'weekly', 'monthly'].
-> **Limitations** A new file is *always* created when the process starts, regardless of `rotate` option; this is to prevent collisions. So if you start and stop the process several times in a row, there will be a new file created each time and a new timer will start at the beginning of the process. There are several time related precision issues when working with JavaScript. The log rotation will happen "close enough" to the desired `rotate` option.
+	 	
+	 **Limitations** When `config` is an `Object`, a new file is *always* created when the process starts, regardless of `rotate` option; this is to prevent collisions. So if you start and stop the process several times in a row, there will be a new file created each time and a new timer will start at the beginning of the process. There are several time related precision issues when working with JavaScript. The log rotation will happen "close enough" to the desired `rotate` option.
 
 ## GoodFile Methods
 ### `goodfile.init(stream, emitter, callback)`


### PR DESCRIPTION
Clarify that a new log file is created when process starts only when Config is an object

Closes #75
